### PR TITLE
Fix GUI desync and item rubberbanding in inventory systems (Fix JewelryData equality)

### DIFF
--- a/src/main/java/io/redspace/ironsjewelry/core/data/JewelryData.java
+++ b/src/main/java/io/redspace/ironsjewelry/core/data/JewelryData.java
@@ -244,15 +244,43 @@ public class JewelryData {
         return this.pattern;
     }
 
+    private static net.minecraft.resources.ResourceLocation getHolderId(net.minecraft.core.Holder<?> holder) {
+        return holder.unwrapKey()
+                .map(net.minecraft.resources.ResourceKey::location)
+                .orElse(net.minecraft.resources.ResourceLocation.parse("irons_jewelry:unknown"));
+    }
+
     @Override
     public int hashCode() {
-        return hashCode;
+        int result = Objects.hashCode(getHolderId(this.pattern));
+        for (Map.Entry<net.minecraft.core.Holder<PartDefinition>, net.minecraft.core.Holder<MaterialDefinition>> entry : this.parts.entrySet()) {
+            result += Objects.hashCode(getHolderId(entry.getKey())) ^ Objects.hashCode(getHolderId(entry.getValue()));
+        }
+        return result;
     }
 
     @Override
     public boolean equals(Object obj) {
-        return obj == this || (obj instanceof JewelryData other
-                && this.pattern.equals(other.pattern)
-                && this.parts.equals(other.parts));
+        if (this == obj) return true;
+        if (!(obj instanceof JewelryData other)) return false;
+
+        if (!Objects.equals(getHolderId(this.pattern), getHolderId(other.pattern))) return false;
+
+        if (this.parts.size() != other.parts.size()) return false;
+
+        for (Map.Entry<net.minecraft.core.Holder<PartDefinition>, net.minecraft.core.Holder<MaterialDefinition>> entry : this.parts.entrySet()) {
+            net.minecraft.resources.ResourceLocation thisPartId = getHolderId(entry.getKey());
+            net.minecraft.resources.ResourceLocation thisMaterialId = getHolderId(entry.getValue());
+
+            net.minecraft.resources.ResourceLocation otherMaterialId = other.parts.entrySet().stream()
+                    .filter(e -> getHolderId(e.getKey()).equals(thisPartId))
+                    .map(e -> getHolderId(e.getValue()))
+                    .findFirst()
+                    .orElse(null);
+
+            if (otherMaterialId == null || !thisMaterialId.equals(otherMaterialId)) return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
### Description
This PR fixes a severe inventory desync and item rubberbanding issue that occurs when interacting with advanced storage systems. Specifically, it resolves a critical compatibility issue with the **Create** mod, where players are completely unable to order or extract jewelry items from a **Create Stock Keeper**.

### The Problem
Currently, `JewelryData#equals` and `JewelryData#hashCode` compare the `Holder` instances of `pattern` and `parts` directly. In Minecraft 1.21, `Holder` implementations often vary between the server and the client (e.g., `Holder.Reference` vs. `Holder.Direct` when items are synced or rendered in virtual UIs). 

Because Java's default `.equals()` fails when comparing different `Holder` types even if they wrap the exact same object, `JewelryData#equals` returns `false` during network transaction checks. When a player tries to request an item from the *Create Stock Keeper*, the server cancels the transaction due to a perceived NBT/Component mismatch. This makes it impossible to order the items, causing them to immediately snap back into the inventory UI (rubberbanding).

### The Solution
Updated `equals()` and `hashCode()` in `JewelryData.java` to bypass the `Holder` wrapper identities. The checks now safely unwrap the holders and evaluate the actual `ResourceLocation` (Registry ID) of the patterns and materials. This guarantees strict value-based equality across network packets, client, and server, matching the standards required for 1.21 Data Components and allowing the *Create Stock Keeper* to successfully process orders.

---
*Note: The proposed code fix and this PR description were generated with the assistance of an AI assistant to help analyze and resolve the 1.21 Data Component synchronization issue.*